### PR TITLE
Refine start screen layout and style

### DIFF
--- a/story_editor_scaffold/story_editor/main_window.py
+++ b/story_editor_scaffold/story_editor/main_window.py
@@ -1,5 +1,18 @@
 import sys
-from PyQt5.QtWidgets import QApplication, QMainWindow, QStackedWidget, QToolBar, QAction, QFileDialog, QMessageBox, QComboBox, QCheckBox, QWidget, QLabel
+from pathlib import Path
+from PyQt5.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QStackedWidget,
+    QToolBar,
+    QAction,
+    QFileDialog,
+    QMessageBox,
+    QComboBox,
+    QCheckBox,
+    QWidget,
+    QLabel,
+)
 from PyQt5.QtCore import QSize
 from .ui.start_screen import StartScreen
 from .ui.editor_screen import EditorScreen
@@ -171,6 +184,10 @@ class MainWindow(QMainWindow):
 
 def main():
     app = QApplication(sys.argv)
+    style_path = Path(__file__).resolve().parent / "resources" / "style.qss"
+    if style_path.exists():
+        with open(style_path) as f:
+            app.setStyleSheet(f.read())
     win = MainWindow()
     win.show()
     sys.exit(app.exec_())

--- a/story_editor_scaffold/story_editor/resources/new_project.svg
+++ b/story_editor_scaffold/story_editor/resources/new_project.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M12 5v14M5 12h14" stroke="black" stroke-width="2" fill="none"/>
+</svg>

--- a/story_editor_scaffold/story_editor/resources/open_project.svg
+++ b/story_editor_scaffold/story_editor/resources/open_project.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 4h7l2 3h9v13H3z" stroke="black" stroke-width="2" fill="none"/>
+</svg>

--- a/story_editor_scaffold/story_editor/resources/recent_projects.svg
+++ b/story_editor_scaffold/story_editor/resources/recent_projects.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="9" stroke="black" stroke-width="2" fill="none"/>
+  <path d="M12 7v5l3 3" stroke="black" stroke-width="2" fill="none"/>
+</svg>

--- a/story_editor_scaffold/story_editor/resources/style.qss
+++ b/story_editor_scaffold/story_editor/resources/style.qss
@@ -1,0 +1,10 @@
+#titleLabel {
+    font-size: 28px;
+    font-weight: bold;
+    margin-bottom: 30px;
+}
+
+#recentLabel {
+    font-size: 16px;
+    margin-top: 40px;
+}

--- a/story_editor_scaffold/story_editor/ui/start_screen.py
+++ b/story_editor_scaffold/story_editor/ui/start_screen.py
@@ -1,5 +1,22 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QLabel, QListWidget, QListWidgetItem, QFileDialog
+from pathlib import Path
+
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QFileDialog,
+    QGroupBox,
+    QFrame,
+    QHBoxLayout,
+    QSpacerItem,
+    QSizePolicy,
+)
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon
+
 from ..core.settings import Settings
 
 class StartScreen(QWidget):
@@ -7,31 +24,58 @@ class StartScreen(QWidget):
         super().__init__()
         self.host = host
         layout = QVBoxLayout(self)
-        layout.setAlignment(Qt.AlignCenter)
+        layout.setAlignment(Qt.AlignTop | Qt.AlignHCenter)
 
-        title = QLabel("📖 Story Editor")
+        res_dir = Path(__file__).resolve().parent.parent / "resources"
+
+        title = QLabel("Story Editor")
         title.setAlignment(Qt.AlignCenter)
-        title.setStyleSheet("font-size: 28px; font-weight: bold; margin-bottom: 30px;")
+        title.setObjectName("titleLabel")
         layout.addWidget(title)
 
-        btn_new = QPushButton("➕ New Project")
+        actions_frame = QFrame()
+        actions_layout = QVBoxLayout(actions_frame)
+
+        btn_new = QPushButton("New Project")
+        btn_new.setObjectName("newButton")
         btn_new.setFixedSize(220, 60)
+        btn_new.setIcon(QIcon(str(res_dir / "new_project.svg")))
         btn_new.clicked.connect(lambda: self.host.open_editor(new=True))
-        layout.addWidget(btn_new, alignment=Qt.AlignCenter)
+        actions_layout.addWidget(btn_new, alignment=Qt.AlignCenter)
 
-        btn_open = QPushButton("📂 Open Project")
+        btn_open = QPushButton("Open Project")
+        btn_open.setObjectName("openButton")
         btn_open.setFixedSize(220, 60)
+        btn_open.setIcon(QIcon(str(res_dir / "open_project.svg")))
         btn_open.clicked.connect(self.open_project)
-        layout.addWidget(btn_open, alignment=Qt.AlignCenter)
+        actions_layout.addWidget(btn_open, alignment=Qt.AlignCenter)
 
+        layout.addWidget(actions_frame, alignment=Qt.AlignCenter)
+
+        layout.addItem(QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding))
+
+        recent_group = QGroupBox()
+        recent_layout = QVBoxLayout(recent_group)
+
+        header_widget = QFrame()
+        header_layout = QHBoxLayout(header_widget)
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        lbl_icon = QLabel()
+        lbl_icon.setPixmap(QIcon(str(res_dir / "recent_projects.svg")).pixmap(16, 16))
+        header_layout.addWidget(lbl_icon)
         recent_label = QLabel("Recent Projects")
-        recent_label.setStyleSheet("font-size: 16px; margin-top: 40px;")
-        layout.addWidget(recent_label, alignment=Qt.AlignCenter)
+        recent_label.setObjectName("recentLabel")
+        header_layout.addWidget(recent_label)
+        header_layout.addStretch()
+        recent_layout.addWidget(header_widget)
 
         self.recent_list = QListWidget()
+        self.recent_list.setObjectName("recentList")
         self.recent_list.setMaximumWidth(500)
         self.recent_list.itemDoubleClicked.connect(self.open_recent)
-        layout.addWidget(self.recent_list, alignment=Qt.AlignCenter)
+        recent_layout.addWidget(self.recent_list)
+
+        layout.addWidget(recent_group, alignment=Qt.AlignCenter)
 
         self.refresh_recent()
 


### PR DESCRIPTION
## Summary
- Replace emoji buttons with SVG icons and regroup start screen layout
- Move inline styles to dedicated QSS stylesheet and assign object names
- Load global style sheet during application startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57c62dfa883219db65992f50cb8f2