### PR TITLE
Scaffold FastAPI RQ pipeline with htmx UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+REDIS_URL=redis://localhost:6379/0
+DATABASE_URL=sqlite:///./edit.db
+STORAGE_ROOT=./storage

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+edit.db
+storage/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # EDIT
+
+Prototype pipeline for semi-automatic video processing: download → speed → cut → ASR → translate → render. Backend uses FastAPI with RQ workers and a minimalist htmx UI.
+
+## Quick start
+
+```bash
+# install deps
+pip install -r backend/requirements.txt
+
+# start redis (or use docker)
+./scripts/dev_redis.sh &
+
+# run API
+uvicorn backend.app.main:app --reload
+
+# run worker
+./scripts/run_worker.sh
+```
+
+Open http://localhost:8000/ to submit jobs and monitor progress.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,23 @@
+"""Application configuration via environment variables.
+
+This module uses ``pydantic-settings``'s :class:`BaseSettings` to load
+configuration values. Pydantic v2 removed ``BaseSettings`` from the core
+package, so we import it from ``pydantic_settings`` for compatibility.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration loaded from environment or ``.env`` file."""
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+    app_name: str = "EDIT"
+    redis_url: str = "redis://localhost:6379/0"
+    database_url: str = "sqlite:///./edit.db"
+    storage_root: str = "./storage"
+
+
+settings = Settings()
+

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,0 +1,15 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .config import settings
+
+engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/jobs_router.py
+++ b/backend/app/jobs_router.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import schemas, models
+from .deps import get_db
+from .queue import queue
+from .workers.pipeline import run_pipeline
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+@router.post("/", response_model=schemas.Job)
+def create_job(payload: schemas.JobCreate, db: Session = Depends(get_db)):
+    job = models.Job(source_url=payload.source_url, show_name=payload.show_name, episode=payload.episode)
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    queue.enqueue(run_pipeline, job.id)
+    return job
+
+
+@router.get("/{job_id}", response_model=schemas.Job)
+def get_job(job_id: int, db: Session = Depends(get_db)):
+    job = db.query(models.Job).filter(models.Job.id == job_id).first()
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from .models import Base
+from .deps import engine
+from .jobs_router import router as jobs_router
+from .views import router as views_router
+
+app = FastAPI(title="EDIT")
+app.include_router(jobs_router)
+app.include_router(views_router)
+app.mount("/static", StaticFiles(directory="backend/app/static"), name="static")
+
+
+@app.on_event("startup")
+def on_startup():
+    Base.metadata.create_all(bind=engine)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, JSON
+from sqlalchemy.orm import declarative_base, relationship
+from datetime import datetime
+
+Base = declarative_base()
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+    id = Column(Integer, primary_key=True, index=True)
+    source_url = Column(String, nullable=False)
+    show_name = Column(String, nullable=False)
+    episode = Column(Integer, nullable=False)
+    state = Column(String, default="queued")
+    error_msg = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    tasks = relationship("Task", back_populates="job", cascade="all, delete-orphan")
+    artifacts = relationship("Artifact", back_populates="job", cascade="all, delete-orphan")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"))
+    name = Column(String, nullable=False)
+    state = Column(String, default="pending")
+    try_count = Column(Integer, default=0)
+    logs = Column(Text, default="")
+    started_at = Column(DateTime)
+    finished_at = Column(DateTime)
+    job = relationship("Job", back_populates="tasks")
+
+
+class Artifact(Base):
+    __tablename__ = "artifacts"
+    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"))
+    type = Column(String, nullable=False)
+    path = Column(String, nullable=False)
+    size = Column(Integer, default=0)
+    meta = Column(JSON, default={})
+    job = relationship("Job", back_populates="artifacts")

--- a/backend/app/queue.py
+++ b/backend/app/queue.py
@@ -1,0 +1,7 @@
+from rq import Queue
+from redis import Redis
+
+from .config import settings
+
+redis_conn = Redis.from_url(settings.redis_url)
+queue = Queue("edit", connection=redis_conn)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Artifact(BaseModel):
+    id: int
+    type: str
+    path: str
+    size: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Task(BaseModel):
+    id: int
+    name: str
+    state: str
+    logs: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class JobCreate(BaseModel):
+    source_url: str
+    show_name: str
+    episode: int
+
+
+class Job(BaseModel):
+    id: int
+    source_url: str
+    show_name: str
+    episode: int
+    state: str
+    created_at: datetime
+    updated_at: datetime
+    tasks: List[Task] = Field(default_factory=list)
+    artifacts: List[Artifact] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/ffmpeg.py
+++ b/backend/app/services/ffmpeg.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+
+def run_cmd(args: list[str]):
+    cmd = ["ffmpeg", "-y"] + args
+    subprocess.run(cmd, check=True)
+
+
+def probe(path: Path) -> dict:
+    cmd = ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", str(path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    import json
+    return json.loads(result.stdout)

--- a/backend/app/services/funasr_client.py
+++ b/backend/app/services/funasr_client.py
@@ -1,0 +1,8 @@
+# Placeholder for FunASR integration
+from pathlib import Path
+
+
+def transcribe(audio: Path) -> Path:
+    """Run ASR and return path to SRT file."""
+    # TODO: call FunASR
+    return audio.with_suffix('.srt')

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -1,0 +1,8 @@
+# Placeholder for Gemini translation
+from pathlib import Path
+
+
+def translate_srt(src: Path, dest: Path):
+    """Translate subtitle file to Vietnamese."""
+    # TODO: call Gemini API
+    dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")

--- a/backend/app/services/srt_utils.py
+++ b/backend/app/services/srt_utils.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from typing import List
+
+
+def read_srt(path: Path) -> List[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def write_srt(lines: List[str], path: Path):
+    path.write_text("\n".join(lines), encoding="utf-8")

--- a/backend/app/services/ytdlp.py
+++ b/backend/app/services/ytdlp.py
@@ -1,0 +1,7 @@
+import subprocess
+from pathlib import Path
+
+
+def download(url: str, output: Path):
+    cmd = ["yt-dlp", url, "-o", str(output)]
+    subprocess.run(cmd, check=True)

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>EDIT Jobs</title>
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" />
+</head>
+<body class="section">
+  <div class="container">
+    <h1 class="title">Jobs</h1>
+    <form hx-post="/jobs" hx-trigger="submit" hx-target="#jobs" hx-swap="beforeend" class="box">
+      <div class="field is-grouped">
+        <p class="control is-expanded">
+          <input class="input" type="url" name="source_url" placeholder="Video URL" required />
+        </p>
+        <p class="control">
+          <input class="input" type="text" name="show_name" placeholder="Show" required />
+        </p>
+        <p class="control">
+          <input class="input" type="number" name="episode" placeholder="Ep" required />
+        </p>
+        <p class="control">
+          <button class="button is-primary" type="submit">Add</button>
+        </p>
+      </div>
+    </form>
+    <div id="jobs">
+      {% for job in jobs %}
+        {% include 'job_row.html' %}
+      {% endfor %}
+    </div>
+  </div>
+</body>
+</html>

--- a/backend/app/templates/job_detail.html
+++ b/backend/app/templates/job_detail.html
@@ -1,0 +1,8 @@
+<div class="box" id="job-{{job.id}}" hx-get="/jobs/{{job.id}}/panel" hx-trigger="load, every 3s" hx-target="#job-{{job.id}}" hx-swap="outerHTML">
+  <p><strong>{{job.show_name}} {{'%02d'|format(job.episode)}}</strong> - {{job.state}}</p>
+  <ul>
+    {% for task in job.tasks %}
+    <li>{{task.name}} - {{task.state}}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/backend/app/templates/job_row.html
+++ b/backend/app/templates/job_row.html
@@ -1,0 +1,3 @@
+<div class="box" id="job-{{job.id}}" hx-get="/jobs/{{job.id}}/panel" hx-trigger="load, every 3s" hx-target="#job-{{job.id}}" hx-swap="outerHTML">
+  <p><strong>{{job.show_name}} {{'%02d'|format(job.episode)}}</strong> - {{job.state}}</p>
+</div>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from .deps import get_db
+from . import models
+
+from fastapi.templating import Jinja2Templates
+
+templates = Jinja2Templates(directory="backend/app/templates")
+
+router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+def index(request: Request, db: Session = Depends(get_db)):
+    jobs = db.query(models.Job).order_by(models.Job.created_at.desc()).all()
+    return templates.TemplateResponse("index.html", {"request": request, "jobs": jobs})
+
+
+@router.get("/jobs/{job_id}/panel", response_class=HTMLResponse)
+def job_panel(job_id: int, request: Request, db: Session = Depends(get_db)):
+    job = db.query(models.Job).get(job_id)
+    return templates.TemplateResponse("job_detail.html", {"request": request, "job": job})

--- a/backend/app/workers/pipeline.py
+++ b/backend/app/workers/pipeline.py
@@ -1,0 +1,51 @@
+import logging
+from sqlalchemy.orm import Session
+from datetime import datetime
+
+from ..deps import SessionLocal
+from .. import models
+from . import steps_download, steps_speed, steps_cut, steps_asr, steps_translate, steps_render, steps_report
+
+logger = logging.getLogger(__name__)
+
+
+STEPS = [
+    ("download", steps_download.run),
+    ("speed", steps_speed.run),
+    ("cut", steps_cut.run),
+    ("asr", steps_asr.run),
+    ("translate", steps_translate.run),
+    ("render", steps_render.run),
+    ("report", steps_report.run),
+]
+
+
+def run_pipeline(job_id: int):
+    db: Session = SessionLocal()
+    job = db.query(models.Job).get(job_id)
+    if not job:
+        logger.error("Job %s not found", job_id)
+        return
+    job.state = "running"
+    db.commit()
+    try:
+        for name, fn in STEPS:
+            task = models.Task(job_id=job_id, name=name, state="running", started_at=datetime.utcnow())
+            db.add(task)
+            db.commit()
+            try:
+                fn(job, db)
+                task.state = "done"
+            except Exception as exc:  # noqa: BLE001
+                task.state = "failed"
+                task.logs = str(exc)
+                job.state = "failed"
+                db.commit()
+                raise
+            finally:
+                task.finished_at = datetime.utcnow()
+                db.commit()
+        job.state = "done"
+        db.commit()
+    finally:
+        db.close()

--- a/backend/app/workers/steps_asr.py
+++ b/backend/app/workers/steps_asr.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Running ASR for job %s", job.id)
+    # TODO: integrate FunASR

--- a/backend/app/workers/steps_cut.py
+++ b/backend/app/workers/steps_cut.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Cutting video for job %s", job.id)
+    # TODO: implement silence-based split

--- a/backend/app/workers/steps_download.py
+++ b/backend/app/workers/steps_download.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Downloading %s", job.source_url)
+    # TODO: implement yt-dlp or ffmpeg download

--- a/backend/app/workers/steps_render.py
+++ b/backend/app/workers/steps_render.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Rendering video for job %s", job.id)
+    # TODO: implement ffmpeg render and subtitles burn-in

--- a/backend/app/workers/steps_report.py
+++ b/backend/app/workers/steps_report.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Generating report for job %s", job.id)
+    # TODO: produce JSON report and store artifact

--- a/backend/app/workers/steps_speed.py
+++ b/backend/app/workers/steps_speed.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Adjusting speed for job %s", job.id)
+    # TODO: implement ffmpeg speed change

--- a/backend/app/workers/steps_translate.py
+++ b/backend/app/workers/steps_translate.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run(job, db):
+    logger.info("Translating subtitles for job %s", job.id)
+    # TODO: integrate Gemini translate

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+pydantic-settings
+jinja2
+rq
+redis
+python-multipart

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,8 @@
+import os
+from rq import Worker
+
+from app.queue import redis_conn
+
+if __name__ == "__main__":
+    worker = Worker(["edit"], connection=redis_conn)
+    worker.work()

--- a/scripts/dev_redis.sh
+++ b/scripts/dev_redis.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+redis-server

--- a/scripts/run_worker.sh
+++ b/scripts/run_worker.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python backend/worker.py


### PR DESCRIPTION
## Summary
- add FastAPI app with job queue using RQ and SQLAlchemy models
- scaffold worker pipeline and placeholder step modules
- create minimal htmx/Bulma interface for managing jobs
- add scripts and env example for running API and worker
- migrate settings and schema models to pydantic v2 and add placeholder static directory

## Testing
- `python -m py_compile $(find backend -name '*.py')`
- `python - <<'PY'
from backend.app.main import app
print('loaded', app)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68af380343c48321af8499647dd95ff5